### PR TITLE
Fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ import 'easy-icon/offline/css/easy-icon-all.css';
 It's very easy to use, you just need to insert the tag anywhere:
 
 ```html
-<i class="ei-spmile"></i>
+<i class="ei-smile"></i>
 ```
 
 It should be noted that the prefixes corresponding to the five modules are different, respectively


### PR DESCRIPTION
# Summary

In a snippet in the readme, under the section 2.3 usage, there is a typo. In the code 'spmile' is mentioned instead of 'smile'

## Screenshots
#### Before
<details>
<summary>Toggle before screenshots</summary>

![Screenshot 2023-05-05 at 15 31 45](https://user-images.githubusercontent.com/33545762/236472053-95a6fdd9-1365-4bc4-a89b-63f491308de9.png)

</details>

#### After
<details>
<summary>Toggle after screenshots</summary>

![Screenshot 2023-05-05 at 15 31 21](https://user-images.githubusercontent.com/33545762/236472090-713d9a1c-692f-4992-bf69-aa5ab59df410.png)

</details>